### PR TITLE
Skip Unsupported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bluenviron/mediamtx:1.11.1-ffmpeg
+FROM bluenviron/mediamtx:1.11.2-ffmpeg
 
 RUN apk add bash vim yq nodejs npm
 


### PR DESCRIPTION
### Context

My PR for skipping unsupported MPEG-TS sources got merged upstream and release. This should restore CDOT camera functionality.