### PR TITLE
Update: mediamtx v1.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM
-ARG MEDIAMTX_BASE_IMAGE=bluenviron/mediamtx:1.19.1-ffmpeg
+ARG MEDIAMTX_BASE_IMAGE=bluenviron/mediamtx:1.19.2-ffmpeg
 ARG MEDIAMTX_REPO=https://github.com/bluenviron/mediamtx.git
-ARG MEDIAMTX_BRANCH=v1.19.0
+ARG MEDIAMTX_BRANCH=v1.19.2
 
 FROM --platform=$BUILDPLATFORM node:24-alpine AS app-builder
 


### PR DESCRIPTION
Update to latest version of MediaMTX to resolve FireFox compatibility issue. 

version 1.19.1 updated the version of pion/dtls being used which fixed the FireFox compatibility issue.
https://github.com/bluenviron/mediamtx/releases#release-v1.19.1
https://github.com/pion/dtls/releases#release-v3.1.4

Updating to 1.19.2 for the latest fixes and improvements: https://github.com/bluenviron/mediamtx/releases#release-v1.19.2