### PR TITLE
Update Token Duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Pending Release
 
+- :bug: Fix HLS proxy streams failing with `403 Invalid or expired signed URL` after 10 minutes of playback. A variant playlist URL is a long lived handle that a player reloads for the life of a live stream, so it is now signed with a session length token rather than a segment length one
+
 ### v9.8.1 - 2026-07-29
 
 - :tada: Expose a `MEDIAMTX_LOGLEVEL` environment variable for setting the MediaMTX log level, wired to a new `MediaMTXLogLevel` CloudFormation parameter (replaces `LOG_LEVEL`/`LogLevel`)

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -22,15 +22,20 @@ export class Manifest {
     ): string {
         const absoluteUrl = new URL(uri, baseUrl).href;
         const resourceHash = Manifest.resourceHash(absoluteUrl);
-        cache.set(`${stream}-${resourceHash}`, absoluteUrl);
 
         const ext = path.parse(new URL(absoluteUrl).pathname).ext;
 
-        if (ext && ext.length > 1) {
-            return generateSignedUrl(config.SigningSecret, stream, resourceHash, ext.slice(1));
-        } else {
+        if (!ext || ext.length <= 1) {
             throw new Err(400, null, `Unsupported media segment type: ${ext}`);
         }
+
+        const { url, expires } = generateSignedUrl(config.SigningSecret, stream, resourceHash, ext.slice(1));
+
+        // The cache entry must outlive the token signed for it, otherwise an
+        // expiring mapping turns into a 404 rather than the resource it signs
+        cache.set(`${stream}-${resourceHash}`, absoluteUrl, expires);
+
+        return url;
     }
 
     static rewriteUriTag(

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -1,18 +1,45 @@
 import jwt from 'jsonwebtoken';
 
+/**
+ * Media segments are fetched once, shortly after the playlist referencing them
+ * is rewritten, so a short lived token is sufficient.
+ */
+export const SEGMENT_TOKEN_TTL_SECONDS = 10 * 60;
+
+/**
+ * Nested playlist URLs are long lived handles rather than one-shot fetches - a
+ * player resolves the variant playlist URL once from the master playlist and
+ * then reloads that same URL for the entire life of a live stream. Their tokens
+ * must therefore outlive a viewing session, not a single request.
+ */
+export const PLAYLIST_TOKEN_TTL_SECONDS = 12 * 60 * 60;
+
+const PLAYLIST_EXTENSIONS = ['m3u8', 'm3u'];
+
+/**
+ * Sign a proxied resource URL, returning the lifetime granted alongside it so
+ * the caller can keep the resource resolvable for at least as long as the token
+ */
 export function generateSignedUrl(
     secret: string,
     path: string,
     hash: string,
     type: string
-): string {
+): { url: string; expires: number } {
+    const expires = PLAYLIST_EXTENSIONS.includes(type.toLowerCase())
+        ? PLAYLIST_TOKEN_TTL_SECONDS
+        : SEGMENT_TOKEN_TTL_SECONDS;
+
     const token = jwt.sign({
         path,
         hash,
         type
-    }, secret, { expiresIn: '10m' });
+    }, secret, { expiresIn: expires });
 
-    return `/stream/${path}/segment.${type}?token=${token}`;
+    return {
+        url: `/stream/${path}/segment.${type}?token=${token}`,
+        expires
+    };
 }
 
 export function verifySignedUrl(

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -1,8 +1,24 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Manifest } from '../lib/manifest.js';
-import { verifySignedUrl } from '../lib/signing.js';
+import {
+    verifySignedUrl,
+    PLAYLIST_TOKEN_TTL_SECONDS,
+    SEGMENT_TOKEN_TTL_SECONDS
+} from '../lib/signing.js';
 import NodeCache from 'node-cache';
+
+function tokenClaims(signedUrl: string) {
+    const token = new URL(`http://example.com${signedUrl}`).searchParams.get('token');
+    assert.ok(token, 'Signed URL should carry a token');
+
+    return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as {
+        hash: string;
+        type: string;
+        iat: number;
+        exp: number;
+    };
+}
 
 test('Manifest.rewrite', async (t) => {
     await t.test('rewrites master playlist', () => {
@@ -84,6 +100,39 @@ segment0.ts
         assert.equal(decodedFirst.hash, decodedSecond.hash, 'Repeated rewrites should reuse the same hash');
         assert.deepEqual(cache.keys(), [`${streamId}-${decodedFirst.hash}`], 'Repeated rewrites should reuse the same cache entry');
         assert.equal(cache.get(`${streamId}-${decodedFirst.hash}`), 'http://example.com/stream/123/segment0.ts');
+    });
+
+    await t.test('grants nested playlists a session-length token', () => {
+        // A player resolves the variant playlist URL once from the master playlist
+        // and then reloads that same URL for the life of the live stream, so a
+        // segment-length token would 403 mid-playback
+        const baseUrl = 'http://example.com/stream/123/playlist.m3u8';
+        const streamId = 'test-stream';
+        const config = { SigningSecret: 'secret' } as any;
+        const cache = new NodeCache();
+
+        const signed = Manifest.rewriteSignedUrl('chunklist_w560439810.m3u8', baseUrl, streamId, config, cache);
+        const claims = tokenClaims(signed);
+
+        assert.equal(claims.type, 'm3u8');
+        assert.equal(claims.exp - claims.iat, PLAYLIST_TOKEN_TTL_SECONDS, 'Playlist token should outlive a viewing session');
+
+        const cacheTtl = cache.getTtl(`${streamId}-${claims.hash}`);
+        assert.ok(cacheTtl && cacheTtl - Date.now() > SEGMENT_TOKEN_TTL_SECONDS * 1000,
+            'Playlist cache entry must outlive the token it signs');
+    });
+
+    await t.test('keeps media segment tokens short lived', () => {
+        const baseUrl = 'http://example.com/stream/123/chunklist.m3u8';
+        const streamId = 'test-stream';
+        const config = { SigningSecret: 'secret' } as any;
+        const cache = new NodeCache();
+
+        const signed = Manifest.rewriteSignedUrl('media_w560439810_606179.ts', baseUrl, streamId, config, cache);
+        const claims = tokenClaims(signed);
+
+        assert.equal(claims.type, 'ts');
+        assert.equal(claims.exp - claims.iat, SEGMENT_TOKEN_TTL_SECONDS, 'Segment tokens should stay short lived');
     });
 });
 


### PR DESCRIPTION
### Context

- :bug: Fix HLS proxy streams failing with `403 Invalid or expired signed URL` after 10 minutes of playback. A variant playlist URL is a long lived handle that a player reloads for the life of a live stream, so it 
is now signed with a session length token rather than a segment length one 