### PR TITLE
Fix RTSP hairpin-NAT source + ephemeral leases dropped from path sync

### DIFF
--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -79,6 +79,7 @@ const containerEnvironment = [
     { Name: 'SigningSecret', Value: cf.sub('{{resolve:secretsmanager:tak-cloudtak-${Environment}/api/secret:SecretString::AWSCURRENT}}') },
     { Name: 'API_URL', Value: cf.join(['https://map.', cf.importValue(cf.join(['tak-vpc-', cf.ref('Environment'), '-hosted-zone-name']))]) },
     { Name: 'CLOUDTAK_Config_media_url', Value: cf.join(['https://', 'video', '.', cf.importValue(cf.join(['tak-vpc-', cf.ref('Environment'), '-hosted-zone-name']))]) },
+    { Name: 'CLOUDTAK_Config_media_ingest_internal_host', Value: cf.ref('MediaIngestInternalHost') },
     { Name: 'ACM_CERTIFICATE_ARN', Value: cf.ref('MediaCertificate') },
     { Name: 'AWS_DEFAULT_REGION', Value: cf.region },
     { Name: 'AWS_REGION', Value: cf.region }
@@ -540,6 +541,11 @@ export default cf.merge({
             Type: 'String',
             AllowedValues: ['debug', 'info', 'warn', 'error'],
             Default: 'warn'
+        },
+        MediaIngestInternalHost: {
+            Description: 'Optional internal hostname to rewrite RTSP proxy sources to when their hostname matches CLOUDTAK_Config_media_url\'s own hostname (avoids a hairpin-NAT pull when this deployment publishes and relays through separate internal hosts). Leave blank to disable rewriting (default).',
+            Type: 'String',
+            Default: ''
         },
         EnableExecute: {
             Description: 'Allow SSH into docker container - should only be enabled for limited debugging',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -3,12 +3,14 @@ export interface Config {
     API_URL: string;
     SigningSecret: string
     CLOUDTAK_Config_media_url: string;
+    CLOUDTAK_Config_media_ingest_internal_host: string;
 }
 
 export const config: Config = {
     silent: false,
     API_URL: String(process.env.API_URL),
     CLOUDTAK_Config_media_url: String(process.env.CLOUDTAK_Config_media_url),
+    CLOUDTAK_Config_media_ingest_internal_host: String(process.env.CLOUDTAK_Config_media_ingest_internal_host || ''),
     SigningSecret: String(process.env.SigningSecret)
 };
 

--- a/lib/payload.ts
+++ b/lib/payload.ts
@@ -1,4 +1,5 @@
 import type { Static } from '@sinclair/typebox';
+import type { Config } from './config.js';
 import { CloudTAKRemotePath, Path } from './types.js';
 
 export function isHLSPath(source: string | null | undefined): boolean {
@@ -6,12 +7,39 @@ export function isHLSPath(source: string | null | undefined): boolean {
     return source.startsWith('http');
 }
 
-export function createPayload(path: Static<typeof CloudTAKRemotePath>): Static<typeof Path> {
+/**
+ * A proxy source's hostname commonly matches this media server's own advertised
+ * CLOUDTAK_Config_media_url - that's correct when an off-host EUD/plugin is
+ * publishing to it, but when this same media server pulls that source to relay
+ * it, resolving its own public hostname back to itself is a hairpin-NAT path
+ * many networks/NAT setups can't route. Rewriting to an internal alias that
+ * resolves directly avoids that, but which alias (if any) is valid is
+ * deployment-specific, so this only rewrites when an operator has opted in via
+ * CLOUDTAK_Config_media_ingest_internal_host; otherwise it's a no-op.
+ */
+export function ingestSource(source: string | null | undefined, config: Config): string | null | undefined {
+    if (!source || !config.CLOUDTAK_Config_media_ingest_internal_host) return source;
+
+    try {
+        const ownHostname = new URL(config.CLOUDTAK_Config_media_url).hostname;
+        const url = new URL(source);
+
+        if (['rtsp:', 'rtsps:'].includes(url.protocol) && url.hostname === ownHostname) {
+            url.hostname = config.CLOUDTAK_Config_media_ingest_internal_host;
+        }
+
+        return url.toString();
+    } catch {
+        return source;
+    }
+}
+
+export function createPayload(path: Static<typeof CloudTAKRemotePath>, config: Config): Static<typeof Path> {
     if (path.proxy) {
         return {
             name: path.path,
             record: path.recording,
-            source: path.proxy,
+            source: ingestSource(path.proxy, config) ?? undefined,
             sourceOnDemand: true
         };
     } else {

--- a/lib/persist.ts
+++ b/lib/persist.ts
@@ -40,7 +40,7 @@ export async function syncPaths(config: Config): Promise<void> {
             continue;
         }
 
-        const payload = createPayload(path);
+        const payload = createPayload(path, config);
 
         if (!exists) {
             await createMediaMTXPath(config, payload);
@@ -175,7 +175,12 @@ export async function listCloudTAKPaths(config: Config): Promise<Map<string, Sta
         const url = new URL(process.env.API_URL + '/api/video/lease');
         url.searchParams.append('limit', String(limit));
         url.searchParams.append('expired', 'false');
-        url.searchParams.append('ephemeral', 'false');
+        // 'false' excluded every ephemeral lease from this list - the exact set
+        // syncPaths() then deletes as "not in CloudTAK's current lease list" on
+        // its next 10s tick, since ephemeral leases (e.g. CoT-carried video) were
+        // invisible to it. 'all' includes them, same as every other lease type;
+        // they're still governed by their own expiration/`expired` filtering.
+        url.searchParams.append('ephemeral', 'all');
         url.searchParams.append('impersonate', 'true');
         url.searchParams.append('page', String(page));
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -14,6 +14,7 @@ const baseConfig: Config = {
     silent: true,
     API_URL: 'http://cloudtak.internal:5000',
     CLOUDTAK_Config_media_url: 'http://media.example.com',
+    CLOUDTAK_Config_media_ingest_internal_host: '',
     SigningSecret: 'test-secret'
 };
 

--- a/test/payload.test.ts
+++ b/test/payload.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createPayload, ingestSource, isHLSPath } from '../lib/payload.js';
+import type { Config } from '../lib/config.js';
+
+const baseConfig: Config = {
+    silent: true,
+    API_URL: 'http://cloudtak.internal:5000',
+    CLOUDTAK_Config_media_url: 'https://video.example.org',
+    CLOUDTAK_Config_media_ingest_internal_host: '',
+    SigningSecret: 'test-secret'
+};
+
+test('isHLSPath', async (t) => {
+    await t.test('true for an http(s) source', () => {
+        assert.equal(isHLSPath('https://example.org/stream.m3u8'), true);
+    });
+
+    await t.test('false for a non-http source', () => {
+        assert.equal(isHLSPath('rtsp://example.org/stream'), false);
+    });
+
+    await t.test('false for a missing source', () => {
+        assert.equal(isHLSPath(null), false);
+        assert.equal(isHLSPath(undefined), false);
+    });
+});
+
+test('ingestSource', async (t) => {
+    await t.test('no-op when CLOUDTAK_Config_media_ingest_internal_host is unset', () => {
+        const source = 'rtsp://video.example.org:8554/mystream';
+        assert.equal(ingestSource(source, baseConfig), source);
+    });
+
+    await t.test('rewrites an RTSP source matching our own hostname when opted in', () => {
+        const config: Config = { ...baseConfig, CLOUDTAK_Config_media_ingest_internal_host: 'mediamtx' };
+        const rewritten = ingestSource('rtsp://video.example.org:8554/mystream', config);
+        assert.equal(rewritten, 'rtsp://mediamtx:8554/mystream');
+    });
+
+    await t.test('leaves RTSP sources pointing elsewhere untouched', () => {
+        const config: Config = { ...baseConfig, CLOUDTAK_Config_media_ingest_internal_host: 'mediamtx' };
+        const source = 'rtsp://camera.example.net:8554/mystream';
+        assert.equal(ingestSource(source, config), source);
+    });
+
+    await t.test('leaves non-RTSP sources untouched even on a hostname match', () => {
+        const config: Config = { ...baseConfig, CLOUDTAK_Config_media_ingest_internal_host: 'mediamtx' };
+        const source = 'https://video.example.org/stream.m3u8';
+        assert.equal(ingestSource(source, config), source);
+    });
+
+    await t.test('passes through unparseable sources unchanged', () => {
+        const config: Config = { ...baseConfig, CLOUDTAK_Config_media_ingest_internal_host: 'mediamtx' };
+        assert.equal(ingestSource('not a url', config), 'not a url');
+    });
+
+    await t.test('passes through a missing source unchanged', () => {
+        const config: Config = { ...baseConfig, CLOUDTAK_Config_media_ingest_internal_host: 'mediamtx' };
+        assert.equal(ingestSource(null, config), null);
+        assert.equal(ingestSource(undefined, config), undefined);
+    });
+});
+
+test('createPayload', async (t) => {
+    await t.test('non-proxy path omits source', () => {
+        const payload = createPayload({
+            id: 1,
+            path: 'mystream',
+            recording: false,
+            proxy: null
+        }, baseConfig);
+
+        assert.deepEqual(payload, {
+            name: 'mystream',
+            record: false
+        });
+    });
+
+    await t.test('proxy path sets source and sourceOnDemand', () => {
+        const payload = createPayload({
+            id: 1,
+            path: 'mystream',
+            recording: true,
+            proxy: 'rtsp://camera.example.net:8554/mystream'
+        }, baseConfig);
+
+        assert.deepEqual(payload, {
+            name: 'mystream',
+            record: true,
+            source: 'rtsp://camera.example.net:8554/mystream',
+            sourceOnDemand: true
+        });
+    });
+
+    await t.test('proxy path rewrites a self-referential RTSP source when opted in', () => {
+        const config: Config = { ...baseConfig, CLOUDTAK_Config_media_ingest_internal_host: 'mediamtx' };
+
+        const payload = createPayload({
+            id: 1,
+            path: 'mystream',
+            recording: false,
+            proxy: 'rtsp://video.example.org:8554/mystream'
+        }, config);
+
+        assert.equal(payload.source, 'rtsp://mediamtx:8554/mystream');
+    });
+});


### PR DESCRIPTION
## Bug 1: `createPayload()` hairpin-NAT source

`createPayload()` sets an RTSP proxy path's `source` to `path.proxy` verbatim. `path.proxy` is CloudTAK's advertised proxy URL for that lease — for an off-host EUD/plugin publishing directly to this media server's own public hostname (`CLOUDTAK_Config_media_url`), that's correct. But when *this server* then pulls that same URL to relay it, it's trying to reach its own public hostname from inside its own network — a hairpin-NAT path many NAT/network setups don't support. The pull hangs indefinitely with no error at any layer.

**Fix:** a new `ingestSource()` helper rewrites the hostname to an internal alias when it matches `CLOUDTAK_Config_media_url`'s own hostname — gated behind a new, empty-by-default `CLOUDTAK_Config_media_ingest_internal_host` env var. Which internal alias (if any) is reachable is deployment-specific, so this only activates when an operator explicitly sets it; unset, it's a no-op and every existing deployment is unaffected. Added a CloudFormation parameter (`MediaIngestInternalHost`) alongside the env var so it's usable in ECS deployments too, matching the existing `MediaMTXLogLevel` pattern.

This was independently confirmed reproducible against a fresh clone of current `main`, separately from wherever it was originally found.

## Bug 2: ephemeral leases deleted by path sync within ~10 seconds

`listCloudTAKPaths()` queries CloudTAK's lease list with `ephemeral=false`. `syncPaths()` runs on a 10-second cron and deletes any MediaMTX path that isn't in that list — so every ephemeral lease (e.g. the one created each time a user opens a CoT-carried video) was invisible to it, and got its path deleted within one cron tick of being created, well before playback could start.

**Fix:** query `ephemeral=all` instead, so ephemeral leases are included/excluded from sync by their own expiration, same as every other lease type. (`ephemeral=all` is an existing, already-supported value on CloudTAK's `/api/video/lease` endpoint — not a new API contract.)

## Testing

- `tsc --noEmit` and `eslint` clean
- New unit tests for `ingestSource()`/`createPayload()` (opt-in rewrite, no-op default, non-matching hosts, non-RTSP sources, malformed URLs)
- CloudFormation template still synthesizes correctly with the new parameter
- Full existing test suite passes unchanged (50/50)
